### PR TITLE
Remove gnu-efi CompareGuid fixup

### DIFF
--- a/boot.h
+++ b/boot.h
@@ -117,17 +117,6 @@
 #define V_ASSERT(a)         P_ASSERT(__FILE__, __LINE__, a)
 
 /*
- * EDK2 and gnu-efi's CompareGuid() return opposite values for a match!
- * EDK2 returns boolean TRUE, whereas gnu-efi returns INTN 0, so we
- * define a common boolean macro that follows EDK2 convention always.
- */
-#if defined(_GNU_EFI)
-#define COMPARE_GUID(a, b) (CompareGuid(a, b) == 0)
-#else
-#define COMPARE_GUID CompareGuid
-#endif
-
-/*
  * Secure string length, that asserts if the string is NULL or if
  * the length is larger than a predetermined value (STRING_MAX)
  */


### PR DESCRIPTION
gnu-efi and EDK2 have the same default CompareGuid since ncroxon/gnu-efi@a093fe03786b15ecabaa0d16f84c8133f76ca0c0 which is included in the version of gnu-efi included with uefi-ntfs post pbatard/uefi-ntfs@963f02b8147a0c0996ab595bbfea94faef8ac829